### PR TITLE
Arrondi dans le calcul de l'âge moyen de la mort

### DIFF
--- a/retraites/SimulateurRetraites.py
+++ b/retraites/SimulateurRetraites.py
@@ -852,7 +852,8 @@ class SimulateurRetraites:
                 S[s][a] = self.B[s][a] * ( Ts[s][a] -  K * ( Ps[s][a] + self.dP[s][a] ) ) 
                 RNV[s][a] =  Ps[s][a] * ( 1.0 - self.TCR[s][a] ) / (U - Ts[s][a]) * self.CNV[s][a]
     
-                age_mort = 60.0 + self.EV[s][round(a+.5-As[s][a])]
+                annee_naissance = round(a + 0.5 - As[s][a])
+                age_mort = 60.0 + self.EV[s][annee_naissance]
                 REV[s][a] = ( age_mort - As[s][a] ) / age_mort
     
         return S, RNV, REV, Depenses

--- a/retraites/SimulateurRetraites.py
+++ b/retraites/SimulateurRetraites.py
@@ -852,7 +852,7 @@ class SimulateurRetraites:
                 S[s][a] = self.B[s][a] * ( Ts[s][a] -  K * ( Ps[s][a] + self.dP[s][a] ) ) 
                 RNV[s][a] =  Ps[s][a] * ( 1.0 - self.TCR[s][a] ) / (U - Ts[s][a]) * self.CNV[s][a]
     
-                tmp = 60.0 + self.EV[s][ int(a+.5-As[s][a]) ]
+                tmp = 60.0 + self.EV[s][round(a+.5-As[s][a])]
                 REV[s][a] = ( tmp - As[s][a] ) / tmp
     
         return S, RNV, REV, Depenses

--- a/retraites/SimulateurRetraites.py
+++ b/retraites/SimulateurRetraites.py
@@ -852,8 +852,8 @@ class SimulateurRetraites:
                 S[s][a] = self.B[s][a] * ( Ts[s][a] -  K * ( Ps[s][a] + self.dP[s][a] ) ) 
                 RNV[s][a] =  Ps[s][a] * ( 1.0 - self.TCR[s][a] ) / (U - Ts[s][a]) * self.CNV[s][a]
     
-                tmp = 60.0 + self.EV[s][round(a+.5-As[s][a])]
-                REV[s][a] = ( tmp - As[s][a] ) / tmp
+                age_mort = 60.0 + self.EV[s][round(a+.5-As[s][a])]
+                REV[s][a] = ( age_mort - As[s][a] ) / age_mort
     
         return S, RNV, REV, Depenses
 


### PR DESCRIPTION
2 corrections dans ``SimulateurRetraites.py`` : 
- Renomme la variable ``tmp``, dont la signification est obscure, par ``age_mort``, dont la signification est claire.
- Change le calcul en prenant l'arrondi ``round`` plutôt que la partie entière ``int`` dans le calcul de l'année de naissance.

Fixes #17.