### PR TITLE
Compare depenses pib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,7 @@ des résultats.
 .. code-block:: python
 
 	from retraites.SimulateurRetraites import SimulateurRetraites
-	simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+	simulateur = SimulateurRetraites()
 	analyse = simulateur.pilotageCOR()
 
 La méthode ``graphiques`` permet de produire les graphiques standard dans l'analyse 

--- a/demo.py
+++ b/demo.py
@@ -3,7 +3,7 @@
 
 from retraites.SimulateurRetraites import SimulateurRetraites
 
-simulateur = SimulateurRetraites('retraites/fileProjection.json')
+simulateur = SimulateurRetraites()
 analyse = simulateur.pilotageCOR()
 analyse.afficheSolutionsSimulateurCOR()
 

--- a/doc/Calcule-naissance-retraite-mort.ipynb
+++ b/doc/Calcule-naissance-retraite-mort.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')"
+    "simulateur = SimulateurRetraites()"
    ]
   },
   {

--- a/doc/CalculePensionAnnuelle/simulation-pension-annuelle.ipynb
+++ b/doc/CalculePensionAnnuelle/simulation-pension-annuelle.ipynb
@@ -27,7 +27,7 @@
    },
    "outputs": [],
    "source": [
-    "simulateur = SimulateurRetraites('../../retraites/fileProjection.json')"
+    "simulateur = SimulateurRetraites()"
    ]
   },
   {

--- a/doc/reforme-Macron-age-vs-pensions.ipynb
+++ b/doc/reforme-Macron-age-vs-pensions.ipynb
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "etudeImpact = EtudeImpact(simulateur)\n",
     "analyse = etudeImpact.calcule()"
    ]

--- a/doc/reformes.ipynb
+++ b/doc/reformes.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "from retraites.SimulateurRetraites import SimulateurRetraites\n",
     "\n",
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "analyse = simulateur.pilotageCOR()\n",
     "\n",
     "import pylab as pl\n",

--- a/doc/reformes2.ipynb
+++ b/doc/reformes2.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "analyse = simulateur.pilotageCOR()"
    ]
   },

--- a/doc/simulation-COR-juin-2019.ipynb
+++ b/doc/simulation-COR-juin-2019.ipynb
@@ -57,7 +57,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "simulateur.dessineConjoncture()\n",
     "simulateur.dessineLegende()"
    ]
@@ -111,7 +111,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "\n",
     "analyse = simulateur.pilotageCOR()\n",
     "\n",

--- a/doc/simulation-Etude-Impact.ipynb
+++ b/doc/simulation-Etude-Impact.ipynb
@@ -71,7 +71,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('../retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "simulateur.dessineConjoncture()\n",
     "simulateur.dessineLegende()"
    ]

--- a/index.ipynb
+++ b/index.ipynb
@@ -45,7 +45,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "simulateur.dessineConjoncture()"
    ]
   },
@@ -86,7 +86,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "\n",
     "analyse = simulateur.pilotageCOR()\n",
     "\n",
@@ -147,7 +147,7 @@
     "Age = 61.0\n",
     "RNV = 1.0\n",
     "\n",
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "analyse = simulateur.pilotageParAgeEtNiveauDeVie(Acible=Age, RNVcible=RNV, Scible=S)\n",
     "\n",
     "pl.figure(figsize=(6,8))\n",
@@ -196,7 +196,7 @@
    "source": [
     "Pcible=simulateur.P[1][2020]\n",
     "\n",
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "pl.figure(figsize=(6,8))\n",
     "pl.suptitle(u'Equilibre financier & ratio pension/salaire fixe',fontsize=12)\n",
     "            \n",
@@ -317,7 +317,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "analyse = simulateur.pilotageParNiveauDeVieEtCotisations(RNVcible=1.0, Scible=0.0)\n",
     "    \n",
     "pl.figure(figsize=(6,8))\n",
@@ -440,7 +440,7 @@
    "source": [
     "Acible = 62 # Age de départ à la retraite\n",
     "\n",
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "analyse = simulateur.pilotageParCotisationsEtAge(Acible=Acible, Scible=0.0) \n",
     "    \n",
     "pl.figure(figsize=(6,8))\n",
@@ -582,7 +582,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "print(\"Données et figure pour article 2\")\n",
     "\n",
     "analyse = simulateur.pilotageParNiveauDeVieEtCotisations(RNVcible=1.0, Scible=0.0)\n",
@@ -735,7 +735,7 @@
     }
    ],
    "source": [
-    "simulateur = SimulateurRetraites('retraites/fileProjection.json')\n",
+    "simulateur = SimulateurRetraites()\n",
     "print(\"Données et figures pour article 3\")\n",
     "\n",
     "Acible = 62.0\n",

--- a/retraites/EtudeImpact.py
+++ b/retraites/EtudeImpact.py
@@ -16,7 +16,7 @@ class EtudeImpact:
         simulateur: un SimulateurRetraites.
         
         Exemple
-        simulateur = SimulateurRetraites('retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         etudeImpact = EtudeImpact(simulateur)
         etudeImpact.calcule()
         Ds = etudeImpact.getDepenses()

--- a/retraites/SimulateurAnalyse.py
+++ b/retraites/SimulateurAnalyse.py
@@ -30,7 +30,7 @@ class SimulateurAnalyse:
                     (par défaut, le répertoire courant)
         
         Exemple
-        simulateur = SimulateurRetraites('retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         analyse = simulateur.pilotageCOR()
         analyse.dessineSimulation()
         """

--- a/retraites/SimulateurRetraites.py
+++ b/retraites/SimulateurRetraites.py
@@ -6,14 +6,18 @@ import json
 from retraites.SimulateurAnalyse import SimulateurAnalyse
 import pylab as pl
 import os
+import retraites
 
 class SimulateurRetraites:
-    def __init__(self, json_filename):
+    def __init__(self, json_filename = None):
         """
         Crée un simulateur à partir d'un fichier d'hypothèses JSON.
         
         Paramètres
-        json_filename : une chaîne de caractère, le nom du fichier JSON contenant les hypothèses
+        json_filename : une chaîne de caractère, le nom du fichier JSON 
+        contenant les hypothèses
+        (par défaut, charge le fichier "fileProjection.json" fournit par le 
+        module)
         pilotage : un entier, la stratégie de pilotage (par défaut, celle du COR)
         
         Description
@@ -32,6 +36,11 @@ class SimulateurRetraites:
         Exemple :
         simulateur = SimulateurRetraites('fileProjection.json')
         """
+        
+        if (json_filename is None):
+            # Loading default JSON data
+            json_filename = os.path.join(retraites.__path__[0], "fileProjection.json")
+            
         # initialisations diverses
         # chargement des donnees du COR pour les 6 scenarios
         
@@ -941,7 +950,7 @@ class SimulateurRetraites:
         pl.tight_layout(rect=[0, 0.03, 1, 0.95])
         return None
     
-    def graphique(self, nom, v = None, taille_fonte_titre = 8, yaxis_lim = [], \
+    def graphique(self, nom, v = None, taille_fonte_titre = 8, yaxis_lim = None, \
                   dessine_legende = False, scenarios_indices = None, 
                   dessine_annees = None):
         """
@@ -953,7 +962,8 @@ class SimulateurRetraites:
         v : variable à dessiner (par défaut, en fonction du nom)
         taille_fonte_titre : taille de la fonte du titre (par défaut, fs=8)
         yaxis_lim : une liste de taille 2, les bornes inférieures et supérieures 
-        de l'axe des ordonnées
+        de l'axe des ordonnées (par défaut, utilise les paramètres de 
+        l'objet)
         dessine_legende : booleen, True si la légende doit être dessinée
         scenarios_indices : une liste d'entiers, la liste des indices des scénarios
         (par défaut, sc = range(1,7))
@@ -982,7 +992,7 @@ class SimulateurRetraites:
             else:
                 raise TypeError('Mauvaise valeur pour le nom : %s' % (nom))
 
-        if scenarios_indices==None:
+        if scenarios_indices is None:
             scenarios_indices = self.scenarios
         
         if dessine_annees is not None:
@@ -1013,13 +1023,12 @@ class SimulateurRetraites:
         pl.title(titre_figure,fontsize=taille_fonte_titre)
         
         # Ajuste les limites de l'axe des ordonnées
-        if yaxis_lim==[]:
+        if yaxis_lim is None:
             # If the use did not set the yaxis_lim
             if nom in self.yaxis_lim.keys():
                 # If the variable name was found in the dictionnary
                 yaxis_lim = self.yaxis_lim[nom]
-
-        if yaxis_lim!=[]:
+        else:
             pl.ylim(bottom=yaxis_lim[0],top=yaxis_lim[1])
 
         if dessine_legende:

--- a/retraites/SimulateurRetraites.py
+++ b/retraites/SimulateurRetraites.py
@@ -34,7 +34,7 @@ class SimulateurRetraites:
             pilotageParNiveauDeVieEtCotisations (sous-entendu et par solde financier)
 
         Exemple :
-        simulateur = SimulateurRetraites('fileProjection.json')
+        simulateur = SimulateurRetraites()
         """
         
         if (json_filename is None):

--- a/tests/test_etudeimpact.py
+++ b/tests/test_etudeimpact.py
@@ -12,7 +12,7 @@ import numpy as np
 class CheckEtudeImpact(unittest.TestCase):
 
     def test_0(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         etudeImpact = EtudeImpact(simulateur)
         analyse = etudeImpact.calcule()
 
@@ -50,7 +50,7 @@ class CheckEtudeImpact(unittest.TestCase):
         return None
 
     def test_AgeParAnnee(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         etudeImpact = EtudeImpact(simulateur)
 
         # Vérifie l'age par année et par génération

--- a/tests/test_retraites.py
+++ b/tests/test_retraites.py
@@ -12,7 +12,28 @@ import tempfile
 
 class CheckSimulateur(unittest.TestCase):
 
-    def test_0(self):
+    def test_Paquet_Defaut(self):
+        # génération des graphes pour le statu quo (COR)
+        simulateur = SimulateurRetraites()
+        
+        pl.figure(figsize=(6,8))
+        pl.suptitle('Projections du COR',fontsize=16)
+        
+        analyse = simulateur.pilotageCOR()
+
+        # Vérifie les ordres de grandeurs des calculs
+        for s in simulateur.scenarios:
+            for a in simulateur.annees:
+                #print("s=%s, a=%s, S=%s" % (s, a, analyse.S[s][a]))
+                np.testing.assert_allclose(analyse.A[s][a], 64.0, atol=4.0)
+                np.testing.assert_allclose(analyse.RNV[s][a], 0.8, atol=0.3)
+                np.testing.assert_allclose(analyse.S[s][a], 0.0, atol=0.02)
+                np.testing.assert_allclose(analyse.REV[s][a], 0.3, atol=0.2)
+                np.testing.assert_allclose(analyse.T[s][a], 0.3, atol=0.3)
+                np.testing.assert_allclose(analyse.P[s][a], 0.5, atol=0.3)
+        return None
+    
+    def test_Specifie_JSON(self):
         # génération des graphes pour le statu quo (COR)
         simulateur = SimulateurRetraites('../retraites/fileProjection.json')
         
@@ -35,7 +56,7 @@ class CheckSimulateur(unittest.TestCase):
     
     def test_graphiques(self):
         # génération des graphes pour le statu quo (COR)
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         
         analyse = simulateur.pilotageCOR()
@@ -112,7 +133,7 @@ class CheckSimulateur(unittest.TestCase):
     
     def test_simulateur_retraites(self):
         # génération des graphes sur la conjoncture
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         simulateur.setDirectoryImage(tempfile.gettempdir())
 
@@ -127,7 +148,7 @@ class CheckSimulateur(unittest.TestCase):
         # Pilotage 1 : calcul à âge et niveau de vie défini
         # génération des graphes pour des réformes à prestation garantie
 
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         S=0.0
         Age=61.0
         RNV = 1.0
@@ -167,7 +188,7 @@ class CheckSimulateur(unittest.TestCase):
         # Pilotage 3 : calcul à cotisations et niveau de vie défini
         # génération des graphes pour la réforme Macron avec maintien du niveau de vie
 
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
                     
         RNV=1.0
         analyse = simulateur.pilotageParNiveauDeVieEtCotisations(RNVcible=RNV, Scible=0.0)
@@ -202,7 +223,7 @@ class CheckSimulateur(unittest.TestCase):
         # génération des graphes pour la réforme Macron avec point indexé sur 
         # le salaire moyen (rapport (pension moyenne/)(salaire moyen) constant égal à celui de 2020)
         
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         pl.figure(figsize=(6,8))
         pl.suptitle(u'Equilibre financier & ratio pension/salaire fixe',fontsize=12)
         
@@ -234,7 +255,7 @@ class CheckSimulateur(unittest.TestCase):
         # Pilotage 3 : calcul à cotisations et niveau de vie défini
         print("Données et figure pour article 2")
         
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         analyse = simulateur.pilotageParNiveauDeVieEtCotisations(RNVcible=1.0, Scible=0.0)
         analyse.setDirectoryImage(tempfile.gettempdir())
             
@@ -272,7 +293,7 @@ class CheckSimulateur(unittest.TestCase):
     
         print("Données et figures pour article 3")
         
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         Age = 62.0
         analyse = simulateur.pilotageParCotisationsEtAge(Acible=Age, Scible=0.0) 
         analyse.setDirectoryImage(tempfile.gettempdir())
@@ -319,7 +340,7 @@ class CheckSimulateur(unittest.TestCase):
     def test_pilotage5(self):
         # Pilotage 5 : calcul à âge et dépenses définis
 
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         analyse = simulateur.pilotageParAgeEtDepenses(Scible=0.0)
         analyse.setDirectoryImage(tempfile.gettempdir())
     
@@ -353,7 +374,7 @@ class CheckSimulateur(unittest.TestCase):
         # Pilotage 5 : calcul à âge et dépenses définis
         # Fixe l'âge à une valeur non nulle
 
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         analyse = simulateur.pilotageParAgeEtDepenses(Acible = 62.0, Scible = 0.0)
         analyse.setDirectoryImage(tempfile.gettempdir())
@@ -385,7 +406,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
     
     def test_pilotageParPensionAgeCotisations(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ps = 0.5
         As = 62.0
@@ -408,7 +429,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParSoldePensionAge(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ss = 0.0
         Ps = 0.5
@@ -431,7 +452,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParSoldePensionCotisations(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ss = 0.0
         Ps = 0.5
@@ -454,7 +475,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParSoldeAgeCotisations(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ss = 0.0
         As = 62.0
@@ -477,7 +498,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParSoldeAgeDepenses(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ss = 0.0
         As = 62.0
@@ -500,7 +521,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParSoldePensionDepenses(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ss = 0.0
         Ps = 0.5
@@ -523,7 +544,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParPensionCotisationsDepenses(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         Ps = 0.5
         Ts = 0.28
@@ -546,7 +567,7 @@ class CheckSimulateur(unittest.TestCase):
         return None
 
     def test_pilotageParAgeCotisationsDepenses(self):
-        simulateur = SimulateurRetraites('../retraites/fileProjection.json')
+        simulateur = SimulateurRetraites()
         
         As = 62.0
         Ts = 0.28


### PR DESCRIPTION
Si le fichier json n'est pas donné, utilise le fichier par défaut. 

Cette PR permet de remplacer le constructeur :
```
simulateur = SimulateurRetraites('retraites/fileProjection.json')
```
par :
```
simulateur = SimulateurRetraites()
```
Dans ce cas, la classe utilise le fichier json par défaut (c'est le cas général) fourni dans le répertoire. 

On peut encore spécifier le chemin du fichier si on souhaite en utiliser un autre, mais ce n'est pas strictement nécessaire. 